### PR TITLE
Write new log file if one does not exist.

### DIFF
--- a/src/nimbot.nim
+++ b/src/nimbot.nim
@@ -234,6 +234,8 @@ routes:
   get "/?":
     let curTime = getTime().getGMTime()
     let path = state.irclogsFilename / curTime.format("dd'-'MM'-'yyyy'.logs'")
+    if not existsFile(path):
+      writeFile(path, $epochTime() & "\n")
     var logs = loadRenderer(path)
     resp logs.renderHTML(request)
 


### PR DESCRIPTION
In reference to #5.

This fix seems suspiciously easy. It works on my machine, but of course the server running the official irclogs is different and I have no way of knowing if this will work there.

It only writes a new file when accessing the base route (irclogs.nim-lang.org), if a log for the current day does not yet exist. It basically copies the behavior in irclog.nim/newLogger (https://github.com/nim-lang/nimbot/blob/master/src/irclog.nim#L40).
