### PR TITLE
Don't write timestamp if log file already exists.

### DIFF
--- a/src/irclog.nim
+++ b/src/irclog.nim
@@ -55,9 +55,11 @@ proc log*(logger: PLogger, msg: TIRCEvent) =
     logger.logFile.close()
     logger.startTime = getTime().getGMTime()
     let log = logger.logFilepath / logger.startTime.format("dd'-'MM'-'yyyy'.logs'")
+    let logExists = existsFile(log)
     doAssert open(logger.logFile, log, fmAppend)
-    # Write start time
-    logger.logFile.writeFlush($epochTime() & "\n")
+    if not logExists:
+      # Write start time
+      logger.logFile.writeFlush($epochTime() & "\n")
     
   case msg.cmd
   of MPrivMsg, MJoin, MPart, MNick, MQuit: # TODO: MTopic? MKick?


### PR DESCRIPTION
In reference to #7.

As I said in my comment on #7, I am not entirely certain that this will fix the issue of the timestamp being written twice. I am still unable to reproduce this on my machine (and I've left this edit running on my local nimbot for 3 days), but after going over the source a number of times, it is the only spot I can see that could be causing the problem. If I am wrong, and you believe this will not fix the problem, please let me know.

Oh, and I would do away with the logExists bool, and just check directly with "if not existsFile(log)", but I cannot. Opening the logger.logFile causes the existsFile check to always pass, regardless of whether the log file actually has any content, such as the timestamp written by my previous pull request. I'm still somewhat new to Nim, but I can't see a less ugly way around this.
