### PR TITLE
Modernise NimBot

### DIFF
--- a/src/irclog.nim
+++ b/src/irclog.nim
@@ -29,7 +29,7 @@ proc writeFlush(file: File, s: string) =
 
 proc newLogger*(logFilepath: string): PLogger =
   let startTime = getTime().utc()
-  let log = logFilepath / startTime.format("dd'-'MM'-'yyyy'.logs'")
+  let log = logFilepath / startTime.format("dd'-'MM'-'yyyy'.json'")
   if existsFile(log):
     result = loadLogger(log)
   else:
@@ -55,7 +55,7 @@ proc log*(logger: PLogger, msg: IRCEvent) =
     # Reset logger.
     logger.logFile.close()
     logger.startTime = getTime().utc()
-    let log = logger.logFilepath / logger.startTime.format("dd'-'MM'-'yyyy'.logs'")
+    let log = logger.logFilepath / logger.startTime.format("dd'-'MM'-'yyyy'.json'")
     doAssert open(logger.logFile, log, fmAppend)
     # Write start time
     logger.logFile.writeFlush($epochTime() & "\n")

--- a/src/irclog.nim
+++ b/src/irclog.nim
@@ -46,7 +46,7 @@ proc `$`(s: seq[string]): string =
   result = "[" & join(escaped, ",") & "]"
 
 proc writeLog(logger: PLogger, msg: IRCEvent) =
-  logger.logFile.writeFlush($$(time: getTime(), msg: msg) & "\n")
+  logger.logFile.writeFlush($(%*{"time": getTime(), "msg": msg}) & "\n")
 
 proc log*(logger: PLogger, msg: IRCEvent) =
   if msg.origin != "#nim" and msg.cmd notin {MQuit, MNick}: return

--- a/src/irclog.nim
+++ b/src/irclog.nim
@@ -3,10 +3,10 @@ from xmltree import escape
 import json except to
 
 type
-  TLogger* = object of TObject # Items get erased when new day starts.
-    startTime*: TTimeInfo
+  TLogger* = object of RootObj # Items get erased when new day starts.
+    startTime*: DateTime
     logFilepath*: string
-    logFile*: TFile
+    logFile*: File
   PLogger* = ref TLogger
 
 const
@@ -14,26 +14,26 @@ const
            fpGroupRead, fpGroupExec, fpOthersRead, fpOthersExec}
 
 proc loadLogger*(f: string): PLogger =
-  new(result)
+  new result
   let logs = readFile(f)
   let lines = logs.splitLines()
   # Line 1: Start time
-  result.startTime = fromSeconds(to[float](lines[0])).getGMTime()
+  result.startTime = fromUnixFloat(to[float](lines[0])).utc()
   if not open(result.logFile, f, fmAppend):
     echo("Warning: Could not open logger: " & f)
   result.logFilepath = f.splitFile.dir
 
-proc writeFlush(file: TFile, s: string) =
+proc writeFlush(file: File, s: string) =
   file.write(s)
   file.flushFile()
 
 proc newLogger*(logFilepath: string): PLogger =
-  let startTime = getTime().getGMTime()
+  let startTime = getTime().utc()
   let log = logFilepath / startTime.format("dd'-'MM'-'yyyy'.logs'")
   if existsFile(log):
     result = loadLogger(log)
   else:
-    new(result)
+    new result
     result.startTime = startTime
     result.logFilepath = logFilepath
     doAssert open(result.logFile, log, fmAppend)
@@ -45,30 +45,30 @@ proc `$`(s: seq[string]): string =
     strutils.escape(x)
   result = "[" & join(escaped, ",") & "]"
 
-proc writeLog(logger: PLogger, msg: TIRCEvent) =
+proc writeLog(logger: PLogger, msg: IRCEvent) =
   logger.logFile.writeFlush($$(time: getTime(), msg: msg) & "\n")
 
-proc log*(logger: PLogger, msg: TIRCEvent) =
+proc log*(logger: PLogger, msg: IRCEvent) =
   if msg.origin != "#nim" and msg.cmd notin {MQuit, MNick}: return
-  if getTime().getGMTime().yearday != logger.startTime.yearday:
+  if getTime().utc().yearday != logger.startTime.yearday:
     # It's time to cycle to next day.
     # Reset logger.
     logger.logFile.close()
-    logger.startTime = getTime().getGMTime()
+    logger.startTime = getTime().utc()
     let log = logger.logFilepath / logger.startTime.format("dd'-'MM'-'yyyy'.logs'")
     doAssert open(logger.logFile, log, fmAppend)
     # Write start time
     logger.logFile.writeFlush($epochTime() & "\n")
-    
+
   case msg.cmd
   of MPrivMsg, MJoin, MPart, MNick, MQuit: # TODO: MTopic? MKick?
     #logger.items.add((getTime(), msg))
     #logger.save(logger.logFilepath / logger.startTime.format("dd'-'MM'-'yyyy'.json'"))
     writeLog(logger, msg)
-  else: nil
+  else: discard
 
 proc log*(logger: PLogger, nick, msg, chan: string) =
-  var m: TIRCEvent
+  var m: IRCEvent
   m.typ = EvMsg
   m.cmd = MPrivMsg
   m.params = @[chan, msg]

--- a/src/irclogrender.nim
+++ b/src/irclogrender.nim
@@ -1,10 +1,11 @@
-import irc, htmlgen, times, strutils, marshal, os, xmltree, re
+import irc, htmlgen, times, strutils, marshal, os, xmltree, re, json
 from jester import Request, makeUri
 import irclog
 
 type
+  Entry = tuple[time: Time, msg: IRCEvent]
   TLogRenderer = object of TLogger
-    items*: seq[tuple[time: Time, msg: IRCEvent]] ## Only used for HTML gen
+    items*: seq[Entry] ## Only used for HTML gen
   PLogRenderer* = ref TLogRenderer
 
 proc loadRenderer*(f: string): PLogRenderer =
@@ -19,7 +20,7 @@ proc loadRenderer*(f: string): PLogRenderer =
   result.logFilepath = f.splitFile.dir
   while i < lines.len:
     if lines[i] != "":
-      result.items.add(to[tuple[time: Time, msg: IRCEvent]](lines[i]))
+      result.items.add(json.to(lines[i].parseJson, Entry))
     inc i
 
 proc renderMessage(msg: string): string =

--- a/src/nimbot.nim
+++ b/src/nimbot.nim
@@ -264,7 +264,7 @@ asyncCheck state.ircClient.run()
 
 var settings = newSettings(port = Port(5001))
 routes:
-  get "/?":
+  get "/":
     let curTime = getTime().utc()
     let path = state.irclogsFilename / curTime.format("dd'-'MM'-'yyyy'.logs'")
     var logs = loadRenderer(path)

--- a/src/nimbot.nim
+++ b/src/nimbot.nim
@@ -19,7 +19,7 @@ const
   ircServer = "irc.freenode.net"
   joinChans = @["#nim", "#nimbuild"]
   announceChans = @["#nimbuild"]
-  botNickname = "NimBotNg"
+  botNickname = "NimBot"
 
 proc getCommandArgs(state: State) =
   for kind, key, value in getOpt():

--- a/src/nimbot.nim
+++ b/src/nimbot.nim
@@ -290,7 +290,7 @@ routes:
         let logsHtml = logsPath.changeFileExt("html")
         cond existsFile(logsHtml)
         resp readFile(logsHtml)
-    of "logs":
+    of "logs", "json":
       resp readFile(logsPath)
     else:
       halt()

--- a/src/nimbot.nim
+++ b/src/nimbot.nim
@@ -266,7 +266,9 @@ var settings = newSettings(port = Port(5001))
 routes:
   get "/":
     let curTime = getTime().utc()
-    let path = state.irclogsFilename / curTime.format("dd'-'MM'-'yyyy'.logs'")
+    var path = state.irclogsFilename / curTime.format("dd'-'MM'-'yyyy'.json'")
+    if not existsFile(path):
+      path = path.changeFileExt("logs")
     var logs = loadRenderer(path)
     resp logs.renderHTML(request)
 
@@ -290,7 +292,9 @@ routes:
         let logsHtml = logsPath.changeFileExt("html")
         cond existsFile(logsHtml)
         resp readFile(logsHtml)
-    of "logs", "json":
+    of "json":
+      resp readFile(logsPath.changeFileExt("json"))
+    of "logs":
       resp readFile(logsPath)
     else:
       halt()

--- a/src/nimbot.nim
+++ b/src/nimbot.nim
@@ -7,7 +7,6 @@ import playground, irclogrender, irclog
 
 
 type
-  IrcEvent = TIrcEvent
   State = ref object
     ircClient: AsyncIRC
     ircServerAddr: string
@@ -20,7 +19,7 @@ const
   ircServer = "irc.freenode.net"
   joinChans = @["#nim", "#nimbuild"]
   announceChans = @["#nimbuild"]
-  botNickname = "NimBot"
+  botNickname = "NimBotNg"
 
 proc getCommandArgs(state: State) =
   for kind, key, value in getOpt():
@@ -45,12 +44,11 @@ proc refreshPackagesJson(state: State) {.async.} =
   if resp.status.startsWith("200"):
     try:
       let body = await resp.body
-      var test = parseJson(body)
       state.packagesJson = base64.encode(body)
     except:
       echo("Got incorrect packages.json, not saving.")
       echo(getCurrentExceptionMsg())
-      if state.packagesJson == nil: raise
+      if state.packagesJson.len == 0: raise
   else:
     echo("Could not retrieve packages.json.")
 
@@ -74,10 +72,10 @@ proc trimGitter(msg: string): string =
 
     result = msg[nickEnd + 2 .. ^1]
 
-proc onIrcEvent(client: AsyncIRC, event: TIrcEvent, state: State) {.async.} =
+proc onIrcEvent(client: AsyncIRC, event: IrcEvent, state: State) {.async.} =
   case event.typ
   of EvConnected:
-    nil
+    discard
   of EvDisconnected, EvTimeout:
     await client.reconnect()
   of EvMsg:
@@ -143,7 +141,7 @@ proc limitCommitMsg(m: string): string =
   return m1
 
 proc onHubMessage(state: State, json: JsonNode) {.async.} =
-  if json.existsKey("payload"):
+  if json.hasKey("payload"):
     if isRepoAnnounced(state, json["payload"]["repository"]["full_name"].str):
       let commitsToAnnounce = min(4, json["payload"]["commits"].len)
       if commitsToAnnounce != 0:
@@ -172,7 +170,7 @@ proc onHubMessage(state: State, json: JsonNode) {.async.} =
         message.add(json["payload"]["repository"]["owner"]["name"].str & "/" &
                               json["payload"]["repository"]["name"].str & " ")
         let theRef = json["payload"]["ref"].str.getBranch()
-        if existsKey(json["payload"], "base_ref"):
+        if json["payload"].hasKey("base_ref"):
           let baseRef = json["payload"]["base_ref"].str.getBranch()
           message.add("New branch: " & baseRef & " -> " & theRef)
         else:
@@ -180,7 +178,7 @@ proc onHubMessage(state: State, json: JsonNode) {.async.} =
 
         message.add(" by " & json["payload"]["pusher"]["name"].str)
         await sendMessage(state, joinChans[0], message)
-  elif json.existsKey("announce"):
+  elif json.hasKey("announce"):
     proc announce(state: State, msg: string, important: bool) {.async.} =
       var newMsg = ""
       if important:
@@ -197,7 +195,7 @@ proc open(): State =
   new(res)
   getCommandArgs(res)
 
-  if res.irclogsFilename.isNil:
+  if res.irclogsFilename.len == 0:
     quit("No IRC logs filename specified.")
 
 
@@ -267,7 +265,7 @@ asyncCheck state.ircClient.run()
 var settings = newSettings(port = Port(5001))
 routes:
   get "/?":
-    let curTime = getTime().getGMTime()
+    let curTime = getTime().utc()
     let path = state.irclogsFilename / curTime.format("dd'-'MM'-'yyyy'.logs'")
     var logs = loadRenderer(path)
     resp logs.renderHTML(request)
@@ -310,7 +308,7 @@ routes:
     resp text, "application/javascript"
 
   get "/packages.json":
-    cond (state.packagesJson != nil)
+    cond (state.packagesJson.len != 0)
 
     resp base64.decode(state.packagesJson), "application/json"
 

--- a/src/public/css/log.css
+++ b/src/public/css/log.css
@@ -1,8 +1,10 @@
 
 body {
-  background-color: #2d2d2d;
-  color: #ffffff;
-  font-size: 12pt;
+  background-color: #171921;
+  color: #f8f8f2;
+  font-family: "Lato", "Helvetica Neue", "HelveticaNeue", Helvetica, Arial, sans-serif;
+  font-size: 1.125rem;
+  font-weight: 400;
 }
 
 table {
@@ -15,42 +17,39 @@ table td, table th {
 }
 
 td.nick {
-  border-left: 1px solid #CC880A;
-  border-right: 1px solid #CC880A;
+  border-left: 1px solid #44475a;
+  border-right: 1px solid #44475a;
   text-align: right;
 }
 
 tr.join td.msg, tr.join td.nick {
-  color: #33DB09;
+  color: #50fa7b;
 }
 
 tr.quit td.msg, tr.quit td.nick {
-  color: #DB2109;
+  color: #ff5555;
 }
 
 tr.nick td.msg, tr.nick td.nick {
-  color: #098BDB;
+  color: #6272a4;
 }
 
 tr.part td.msg, tr.part td.nick {
-  color: #DB9909;
+  color: #ffb86c;
 }
 
 tr.action td.msg, tr.action td.nick {
   color: #C609DB;
 }
 
-a:link {
-  color: #F2A20C;
-
+a:link, a:visited {
+  color: #8be9fd;
+  text-decoration: none;
 }
 
 a:hover {
-  color: #CC880A;
-}
-
-a:visited {
-  color: rgb(161, 159, 7);
+  color: #8be9fd;
+  text-decoration: underline;
 }
 
 #controls {
@@ -59,7 +58,7 @@ a:visited {
 }
 
 hr {
-  background-color: #CC880A;
+  background-color: #44475a;
   border:0;
   height: 2px;
 }
@@ -70,7 +69,7 @@ td.selected {
 }
 
 a.time {
-  color: #FFFFFF;
+  color: #f8f8f2;
   text-decoration: none;
 }
 


### PR DESCRIPTION
This makes NimBot compile with the latest stable (although after e2442ae it does require: https://github.com/nim-lang/nim/pull/14549 to properly de-/serialise). It also adds support for various IRC styles (italics, bold, underline, and colours (only foreground at the moment)) and colouring of IRC nicknames. Along with this the stylesheet is updated to look more like the darkmode documentation and the main Nim website. Care has been taken to make sure that it can still parse the old log format, so it should be able to run with the old NimBot log files so that old logs are still accessible.

As an indication of what the new logs look like:
![newlogs](https://user-images.githubusercontent.com/2845482/83542646-c5705f80-a4ea-11ea-93ef-9827284a13f7.png)
